### PR TITLE
Bump enonic libs for XP 8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-util = "3.1.1"
+util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }


### PR DESCRIPTION
## Summary

Pin `lib-util` to the next-major SNAPSHOT published from the lib's master branch (XP 8 line). Not releasing yet — consumers track SNAPSHOTs from the Enonic dev repo.

## Bumps

| Lib | Before | After |
| --- | --- | --- |
| `com.enonic.lib:lib-util` | `3.1.1` | `4.0.0-SNAPSHOT` |

The new pin is a SNAPSHOT and resolves from `xp.enonicRepo('dev')`, which is already declared in `build.gradle`'s `repositories {}` block (added in #34). No new repository declaration was needed.

This consumer pulls only `lib-util` from the bumped set (`lib-menu` and `lib-explorer` are not used here), so only the `util` version in `gradle/libs.versions.toml` changed.

## Excludes audit

None to audit — the existing `dependencies {}` block uses bare `include` statements with no `exclude` clauses on any of the lib deps. Nothing to remove or keep.

## Verification

- `./gradlew clean build` is green.
- `./gradlew dependencies --configuration include` confirms `com.enonic.lib:lib-util:4.0.0-SNAPSHOT` resolves cleanly with no version conflicts.
- Runtime verification was not performed.

## Test plan

- [x] `./gradlew clean build` green locally
- [x] Dependency tree confirms `lib-util:4.0.0-SNAPSHOT` resolves from the dev repo
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)