### PR TITLE
Bump version to 2.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ group = com.enonic.app
 projectName = facebook.pixel
 appName = com.enonic.app.facebook.pixel
 xpVersion=8.0.0-B4
-version=1.2.0-SNAPSHOT
+version=2.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bumps master `version` from `1.2.0-SNAPSHOT` to `2.0.0-SNAPSHOT` for the XP 8 line.
- Adds `releaseBranch: master | 1.x` to `.github/workflows/enonic-gradle.yml` so both branches are recognized as release branches by `enonic/release-tools/build-and-publish`.
- The XP 7 maintenance line continues on the new `1.x` branch (created from the post-`v1.1.0` SNAPSHOT-bump commit `e16525c`).

## Test plan
- [ ] CI green on this PR
- [ ] After merge: `./gradlew clean build` from master is green
- [ ] After merge: a CI run on `1.x` (once the `1.x` PR also merges) classifies it as a release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)