### PR TITLE
Add release-branch CI config for 1.x

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -1,0 +1,29 @@
+name: Gradle Build
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.build-and-publish.outputs.release }}
+    steps:
+      - id: build-and-publish
+        uses: enonic/release-tools/build-and-publish@master
+        with:
+          repoUser: ci
+          repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            1.x
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs: build
+    if: needs.build.outputs.release == 'true'
+
+    steps:
+      - uses: enonic/release-tools/release@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds the `enonic-gradle.yml` workflow on `1.x` with `releaseBranch: master | 1.x` so pushes here are recognized as release-branch builds.
- The workflow file did not exist at the maintenance branch's source commit (`e16525c`), so this PR creates it from master's pre-bump version with the `releaseBranch` block added — no version bump, no docgen / versions.json changes (those are master-only, per the app-booster reference).

## Test plan
- [ ] CI green on this PR
- [ ] After merge: a CI run on `1.x` classifies it as a release branch via `enonic/release-tools/build-and-publish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)