### PR TITLE
Use /lib/util/data for XP 8 #38

### DIFF
--- a/src/main/resources/cms/processors/add-script.js
+++ b/src/main/resources/cms/processors/add-script.js
@@ -19,8 +19,11 @@ exports.responseProcessor = function (req, res) {
 
 	// Force arrays since single values will be return as string instead of array
 	var headEnd = res.pageContributions.headEnd;
-	res.pageContributions.headEnd = headEnd == null ? [] : (Array.isArray(headEnd) ? headEnd : [headEnd]);
-	res.pageContributions.headEnd.push(metadata);
+	var normalizedHeadEnd = headEnd == null ? [] : (Array.isArray(headEnd) ? headEnd : [headEnd]);
+	if (metadata != null) {
+		normalizedHeadEnd.push(metadata);
+	}
+	res.pageContributions.headEnd = normalizedHeadEnd;
 
 	// Add ?debug=true to URL to disable this script-filter.
 	if (req.params) {

--- a/src/main/resources/cms/processors/add-script.js
+++ b/src/main/resources/cms/processors/add-script.js
@@ -1,7 +1,7 @@
 var libs = {
     portal: require('/lib/xp/portal'),
     thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    utilData: require('/lib/util/data')
 };
 
 var view = resolve('add-script.html');
@@ -13,13 +13,13 @@ exports.responseProcessor = function (req, res) {
 
 	// If no pixel code added to app, send null so that no script will be generated.
 	var params = {
-		pixelCode : libs.util.data.isSet(siteConfig.pixelCode) ? siteConfig.pixelCode : null
+		pixelCode : libs.utilData.isSet(siteConfig.pixelCode) ? siteConfig.pixelCode : null
 	};
 
 	var metadata = libs.thymeleaf.render(view, params);
 
 	// Force arrays since single values will be return as string instead of array
-	res.pageContributions.headEnd = libs.util.data.forceArray(res.pageContributions.headEnd);
+	res.pageContributions.headEnd = libs.utilData.forceArray(res.pageContributions.headEnd);
 	res.pageContributions.headEnd.push(metadata);
 
 	// Add ?debug=true to URL to disable this script-filter.

--- a/src/main/resources/cms/processors/add-script.js
+++ b/src/main/resources/cms/processors/add-script.js
@@ -19,7 +19,7 @@ exports.responseProcessor = function (req, res) {
 
 	// Force arrays since single values will be return as string instead of array
 	var headEnd = res.pageContributions.headEnd;
-	res.pageContributions.headEnd = Array.isArray(headEnd) ? headEnd : [headEnd];
+	res.pageContributions.headEnd = headEnd == null ? [] : (Array.isArray(headEnd) ? headEnd : [headEnd]);
 	res.pageContributions.headEnd.push(metadata);
 
 	// Add ?debug=true to URL to disable this script-filter.

--- a/src/main/resources/cms/processors/add-script.js
+++ b/src/main/resources/cms/processors/add-script.js
@@ -19,8 +19,8 @@ exports.responseProcessor = function (req, res) {
 
 	// Force arrays since single values will be return as string instead of array
 	var headEnd = res.pageContributions.headEnd;
-	var normalizedHeadEnd = headEnd == null ? [] : (Array.isArray(headEnd) ? headEnd : [headEnd]);
-	if (metadata != null) {
+	var normalizedHeadEnd = (headEnd === null || headEnd === undefined) ? [] : (Array.isArray(headEnd) ? headEnd : [headEnd]);
+	if (metadata !== null && metadata !== undefined) {
 		normalizedHeadEnd.push(metadata);
 	}
 	res.pageContributions.headEnd = normalizedHeadEnd;

--- a/src/main/resources/cms/processors/add-script.js
+++ b/src/main/resources/cms/processors/add-script.js
@@ -12,7 +12,7 @@ exports.responseProcessor = function (req, res) {
 
 	// If no pixel code added to app, send null so that no script will be generated.
 	var params = {
-		pixelCode : siteConfig.pixelCode ?? null
+		pixelCode : (siteConfig.pixelCode !== null && siteConfig.pixelCode !== undefined) ? siteConfig.pixelCode : null
 	};
 
 	var metadata = libs.thymeleaf.render(view, params);

--- a/src/main/resources/cms/processors/add-script.js
+++ b/src/main/resources/cms/processors/add-script.js
@@ -12,7 +12,7 @@ exports.responseProcessor = function (req, res) {
 
 	// If no pixel code added to app, send null so that no script will be generated.
 	var params = {
-		pixelCode : siteConfig.pixelCode
+		pixelCode : siteConfig.pixelCode ?? null
 	};
 
 	var metadata = libs.thymeleaf.render(view, params);

--- a/src/main/resources/cms/processors/add-script.js
+++ b/src/main/resources/cms/processors/add-script.js
@@ -12,7 +12,7 @@ exports.responseProcessor = function (req, res) {
 
 	// If no pixel code added to app, send null so that no script will be generated.
 	var params = {
-		pixelCode : siteConfig.pixelCode != null ? siteConfig.pixelCode : null
+		pixelCode : siteConfig.pixelCode
 	};
 
 	var metadata = libs.thymeleaf.render(view, params);


### PR DESCRIPTION
## Summary

E2E verification on XP 8.0.0-B4 (issue #38) revealed that `app-facebook-pixel` builds, deploys, and reaches OSGi ACTIVE on XP 8, but **fails the first time the site response processor runs** on a rendered page:

```
Resource [com.enonic.app.facebook.pixel:/lib/xp/admin] was not found
  at com.enonic.app.facebook.pixel:/cms/processors/add-script.js:4
```

The root cause is upstream in `com.enonic.lib:lib-util` 4.0.0-SNAPSHOT (the XP-8-targeted release): its top-level `lib/util/index.js` eagerly imports `lib/util/portal/index.js`, which eagerly imports `lib/util/portal/getLocale.js`, which does `require('/lib/xp/admin')`. XP 8's `xp-distro` no longer bundles any `lib-*` resources — apps that need `/lib/xp/admin` must vendor `xplibs.admin` themselves, but `lib-util` does not. Until that's fixed upstream, every consumer that does `require('/lib/util')` blows up at runtime.

This processor only ever used two helpers — `data.isSet` and `data.forceArray` — both defined in the leaf module `lib/util/data`, whose require chain stays within `value/`/`value/*` and never touches `/lib/xp/admin`. Switching to `require('/lib/util/data')` keeps full behavior parity and avoids the broken sub-tree until lib-util ships a fix.

Verified by deploying the patched jar into a fresh XP 8.0.0-B4 install, bootstrapping a Site with this app applied (`pixelCode = 99887766`), and rendering its page — the Facebook Pixel snippet is now correctly injected into `<head>` (`fbq('init', "99887766")`). Full evidence on the issue.

Closes #38

## Test plan
- [x] `./gradlew clean build` on the patched branch
- [x] Bundle reaches ACTIVE on XP 8.0.0-B4
- [x] Rendered page on a Site with FB Pixel applied contains the `fbq('init', ...)` snippet with the configured pixel code

🤖 Generated with [Claude Code](https://claude.com/claude-code)