### PR TITLE
Drop lib-util

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,6 @@ dependencies {
     include xplibs.content
     include xplibs.portal
     include libs.lib.thymeleaf
-    include libs.lib.util
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,5 @@
 [versions]
 thymeleaf = "3.0.0-SNAPSHOT"
-util = "4.0.0-SNAPSHOT"
 
 [libraries]
 lib-thymeleaf = { module = "com.enonic.lib:lib-thymeleaf", version.ref = "thymeleaf" }
-lib-util = { module = "com.enonic.lib:lib-util", version.ref = "util" }

--- a/src/main/resources/cms/processors/add-script.js
+++ b/src/main/resources/cms/processors/add-script.js
@@ -1,7 +1,6 @@
 var libs = {
     portal: require('/lib/xp/portal'),
-    thymeleaf: require('/lib/thymeleaf'),
-    util: require('/lib/util')
+    thymeleaf: require('/lib/thymeleaf')
 };
 
 var view = resolve('add-script.html');
@@ -13,13 +12,14 @@ exports.responseProcessor = function (req, res) {
 
 	// If no pixel code added to app, send null so that no script will be generated.
 	var params = {
-		pixelCode : libs.util.data.isSet(siteConfig.pixelCode) ? siteConfig.pixelCode : null
+		pixelCode : siteConfig.pixelCode != null ? siteConfig.pixelCode : null
 	};
 
 	var metadata = libs.thymeleaf.render(view, params);
 
 	// Force arrays since single values will be return as string instead of array
-	res.pageContributions.headEnd = libs.util.data.forceArray(res.pageContributions.headEnd);
+	var headEnd = res.pageContributions.headEnd;
+	res.pageContributions.headEnd = Array.isArray(headEnd) ? headEnd : [headEnd];
 	res.pageContributions.headEnd.push(metadata);
 
 	// Add ?debug=true to URL to disable this script-filter.


### PR DESCRIPTION
## Summary

Removes the `lib-util` dependency from `app-facebook-pixel` by inlining its two helpers at the only call site.

### Replacements

| call | inline |
|---|---|
| `util.data.isSet(x)` | `(x != null)` |
| `util.data.forceArray(x)` | `(Array.isArray(x) ? x : [x])` |

### Files touched

- `src/main/resources/cms/processors/add-script.js` — drop `require('/lib/util')`, inline `isSet` and `forceArray`.
- `build.gradle` — drop `include libs.lib.util`.
- `gradle/libs.versions.toml` — drop `util` version and `lib-util` library entries.

### Why

`lib-util` 4.0.0-SNAPSHOT's index eagerly loads `portal/getLocale`, which requires `/lib/xp/admin` — a resource XP 8's distro no longer exposes. Rather than keep the fragile dependency, we inline the two helpers we actually use. This supersedes #39 (which only sidestepped the broken portal/* sub-tree by importing `/lib/util/data` directly); after this PR, the app has no lib-util requirement of any kind.

Behavior is byte-identical: `isSet(x)` in lib-util is exactly `x != null`, and `forceArray(x)` returns `[x]` for non-arrays (including `null` → `[null]`), which `Array.isArray(x) ? x : [x]` matches.

## Test plan

- [x] `./gradlew build --refresh-dependencies` succeeds locally.
- [ ] CI green.
- [ ] Manual smoke (optional, covered by the issue #38 E2E plan): site config with a `pixelCode` set still injects the FB Pixel `<script>` into `headEnd`; empty/missing `pixelCode` injects no script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)